### PR TITLE
feat: add checkerr flag to report code errors and skip binary generation

### DIFF
--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -85,6 +85,7 @@ var (
 	BuildPkgdir            string                  // -pkgdir flag
 	BuildRace              bool                    // -race flag
 	BuildToolexec          []string                // -toolexec flag
+	BuildCheckError        bool                    // -checkerr flag
 	BuildToolchainName     string
 	BuildToolchainCompiler func() string
 	BuildToolchainLinker   func() string

--- a/src/cmd/go/internal/work/action.go
+++ b/src/cmd/go/internal/work/action.go
@@ -430,7 +430,7 @@ func (b *Builder) cacheAction(mode string, p *load.Package, f func() *Action) *A
 
 // AutoAction returns the "right" action for go build or go install of p.
 func (b *Builder) AutoAction(mode, depMode BuildMode, p *load.Package) *Action {
-	if p.Name == "main" {
+	if !cfg.BuildCheckError && p.Name == "main" {
 		return b.LinkAction(mode, depMode, p)
 	}
 	return b.CompileAction(mode, depMode, p)

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -237,6 +237,7 @@ func init() {
 
 	AddBuildFlags(CmdBuild, DefaultBuildFlags)
 	AddBuildFlags(CmdInstall, DefaultBuildFlags)
+	CmdInstall.Flag.BoolVar(&cfg.BuildCheckError, "checkerr", false, "set to true to validate only compilation errors and skip binary generation")
 	if cfg.Experiment != nil && cfg.Experiment.CoverageRedesign {
 		AddCoverFlags(CmdBuild, nil)
 		AddCoverFlags(CmdInstall, nil)


### PR DESCRIPTION
New flag -checkerr will skip costly binary generation and report only the compilation errors. This will greatly reduce the time taken to validate changes in go codebase and reduce cpu and memory usage by go toolchain.

To understand the benefits, check the below screenshot where a gamma/frontend server is validated using normal go install command and custom go tool from this branch with -errcheck flag. The commands are run with all the packages already cached in go mod cache from previous runs. Binary with this flag takes only ~2s while the usual command takes >1m. Memory foot print for link step used in the usual install command consumes ~2.9 GB which is completely avoided when errcheck flag is used. 

![Screenshot 2024-02-24 at 11 37 13 PM](https://github.com/epiFi/go/assets/19180816/c7f39eac-9fed-47ad-93fb-584af442d822)

![image](https://github.com/epiFi/go/assets/19180816/f970b2c5-e305-4a8d-9f0e-1659fd35981a)


Alternatives considered:
- [gotype](https://pkg.go.dev/golang.org/x/tools/cmd/gotype) is too slow 
- gofmt reports errors only in the given packages and not from all the dependencies. So this cannot be considered as an equivalent check done by go install/build commands.

 