### PR TITLE
feat: add checkerr flag to report code errors and skip binary generation

### DIFF
--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -88,6 +88,7 @@ var (
 	BuildPkgdir            string                  // -pkgdir flag
 	BuildRace              bool                    // -race flag
 	BuildToolexec          []string                // -toolexec flag
+	BuildCheckError        bool                    // -checkerr flag
 	BuildToolchainName     string
 	BuildToolchainCompiler func() string
 	BuildToolchainLinker   func() string

--- a/src/cmd/go/internal/work/action.go
+++ b/src/cmd/go/internal/work/action.go
@@ -434,7 +434,7 @@ func (b *Builder) cacheAction(mode string, p *load.Package, f func() *Action) *A
 
 // AutoAction returns the "right" action for go build or go install of p.
 func (b *Builder) AutoAction(mode, depMode BuildMode, p *load.Package) *Action {
-	if p.Name == "main" {
+	if !cfg.BuildCheckError && p.Name == "main" {
 		return b.LinkAction(mode, depMode, p)
 	}
 	return b.CompileAction(mode, depMode, p)

--- a/src/cmd/go/internal/work/build.go
+++ b/src/cmd/go/internal/work/build.go
@@ -247,6 +247,7 @@ func init() {
 
 	AddBuildFlags(CmdBuild, DefaultBuildFlags)
 	AddBuildFlags(CmdInstall, DefaultBuildFlags)
+	CmdInstall.Flag.BoolVar(&cfg.BuildCheckError, "checkerr", false, "set to true to validate only compilation errors and skip binary generation")
 	if cfg.Experiment != nil && cfg.Experiment.CoverageRedesign {
 		AddCoverFlags(CmdBuild, nil)
 		AddCoverFlags(CmdInstall, nil)


### PR DESCRIPTION
New flag -checkerr will skip costly binary generation and report only the compilation errors. This will greatly reduce the time taken to validate changes in go codebase and reduce cpu and memory usage by go toolchain.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
